### PR TITLE
Recomposition fix

### DIFF
--- a/app/src/main/java/com/example/composelearning/Debug.kt
+++ b/app/src/main/java/com/example/composelearning/Debug.kt
@@ -1,0 +1,15 @@
+package com.example.composelearning
+
+import android.util.Log
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
+
+class Ref(var value: Int)
+
+@Composable
+inline fun LogCompositions(tag: String) {
+    val ref = remember { Ref(0) }
+    SideEffect { ref.value++ }
+    Log.d("RecompositionTrack", "$tag Compositions: ${ref.value}")
+}

--- a/app/src/main/java/com/example/composelearning/DummyState.kt
+++ b/app/src/main/java/com/example/composelearning/DummyState.kt
@@ -1,0 +1,132 @@
+package com.example.composelearning
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+
+@Stable
+@Immutable
+data class DummyState(
+    val progress: Int = 0,
+    val content: String = "content",
+    val random: Int = 0
+)
+
+class DummyViewModel : ViewModel() {
+    val state = MutableStateFlow(DummyState())
+
+    fun onStartProgress() = viewModelScope.launch {
+        repeat(10) {
+            delay(200)
+            state.value = state.value.copy(progress = it)
+        }
+    }
+
+    fun updateContent() = viewModelScope.launch {
+        state.value = state.value.copy(content = "${System.currentTimeMillis()}")
+    }
+
+    fun updateRandom(random: Int) = viewModelScope.launch {
+        state.value = state.value.copy(random = random)
+    }
+}
+
+@Composable
+fun RootView(modifier: Modifier) {
+    LogCompositions(tag = "RootView")
+    val viewModel: DummyViewModel = viewModel()
+    //pass lambda from outside or use method reference like viewModel::updateRandom
+    val updateRandom: (Int) -> Unit = { viewModel.updateRandom(it) }
+    RenderContent(modifier, viewModel, updateRandom)
+}
+
+@Composable
+fun RenderContent(
+    modifier: Modifier,
+    viewModel: DummyViewModel = viewModel(),
+    updateRandom: (Int) -> Unit
+) {
+    LogCompositions(tag = "RenderContent")
+    val state by viewModel.state.collectAsState()
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(Color.DarkGray),
+        verticalArrangement = Arrangement.SpaceEvenly,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(text = "Callback From outside")
+        ContentText(
+            content = state.content,
+            updateContent = viewModel::updateContent
+        )
+        StartProgress(
+            progress = state.progress,
+            onStartProgress = viewModel::onStartProgress
+        )
+        RandomButton(random = state.random, updateRandom = updateRandom)
+    }
+}
+
+@Composable
+private fun ContentText(
+    content: String,
+    updateContent: () -> Unit = {}
+) {
+    LogCompositions(tag = "ContentText ${updateContent.hashCode()}")
+    Row {
+        Button(onClick = updateContent) {
+            Text(text = "Out")
+        }
+        Text(text = content)
+    }
+}
+
+@Composable
+private fun RandomButton(
+    random: Int,
+    updateRandom: (Int) -> Unit
+) {
+    LogCompositions(tag = "RandomButton ${updateRandom.hashCode()}")
+    Row {
+        Button(onClick = { updateRandom(dummyList.random()) }) {
+            Text(text = "Random")
+        }
+        Text(text = "$random")
+    }
+}
+
+@Composable
+private fun StartProgress(
+    progress: Int,
+    onStartProgress: () -> Unit = {}
+) {
+    LogCompositions(tag = "StartProgress ${onStartProgress.hashCode()}")
+    Row {
+        Button(onClick = onStartProgress) {
+            Text(text = "Start Progress")
+        }
+        Text(text = "$progress")
+    }
+}
+
+val dummyList = listOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)

--- a/app/src/main/java/com/example/composelearning/MainActivity.kt
+++ b/app/src/main/java/com/example/composelearning/MainActivity.kt
@@ -1,7 +1,6 @@
 package com.example.composelearning
 
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
@@ -16,7 +15,6 @@ import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -75,9 +73,7 @@ class MainActivity : ComponentActivity() {
                 onStartProgress = viewModel::onStartProgress
             )
 
-            ChangeRandomButton(random = state.random) {
-                viewModel.updateRandom(it)
-            }
+            ChangeRandomButton(random = state.random, changeRandom = viewModel::updateRandom)
 
             //A Unstable Object
             TestView()
@@ -205,15 +201,6 @@ class MainActivity : ComponentActivity() {
         Text(text = "${exoplayer.hashCode()}")
     }
 
-}
-
-class Ref(var value: Int)
-
-@Composable
-inline fun LogCompositions(tag: String) {
-    val ref = remember { Ref(0) }
-    SideEffect { ref.value++ }
-    Log.d("RecompositionTrack", "$tag Compositions: ${ref.value}")
 }
 
 val list = listOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)

--- a/app/src/main/java/com/example/composelearning/MainActivity.kt
+++ b/app/src/main/java/com/example/composelearning/MainActivity.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,7 +29,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.google.android.exoplayer2.ExoPlayer
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
 
@@ -49,9 +47,6 @@ class MainActivity : ComponentActivity() {
     private fun ColumnScope.RootViewMvi() {
         LogCompositions(tag = "RootViewMvi")
         val viewModel: MyViewModel = viewModel()
-        val outsideCallback: () -> Unit = {
-            viewModel.onChangeConstantValue()
-        }
         val state by viewModel.state.collectAsState()
         Column(
             modifier = Modifier
@@ -65,19 +60,20 @@ class MainActivity : ComponentActivity() {
             //Callback created inside Composable
             CallbackFromOutSide(
                 content = state.contantValue,
-                outsideCallback = {
-                    outsideCallback()
-                })
+                outsideCallback = viewModel::onChangeConstantValue
+            )
 
             // Callback created inside Composable
-            ChangeContantButton(content = state.contantValue, changeContent = {
-                viewModel.onChangeConstantValue()
-            })
+            ChangeContantButton(
+                content = state.contantValue,
+                changeContent = viewModel::onChangeConstantValue
+            )
 
             //View Listening to progress
-            StartProgressButton(progress = state.progress) {
-                viewModel.onStartProgress()
-            }
+            StartProgressButton(
+                progress = state.progress,
+                onStartProgress = viewModel::onStartProgress
+            )
 
             ChangeRandomButton(random = state.random) {
                 viewModel.updateRandom(it)

--- a/app/src/main/java/com/example/composelearning/MainActivity.kt
+++ b/app/src/main/java/com/example/composelearning/MainActivity.kt
@@ -37,6 +37,8 @@ class MainActivity : ComponentActivity() {
                 RootViewMvi()
                 Divider()
                 RootViewNoMvi()
+                Divider()
+                RootView(Modifier.weight(1f))
             }
         }
     }


### PR DESCRIPTION
Whenever state changes ParentFunction will recompose and it will recreate all the lambdas again. We have to use method references like `viewModel::doSomething` or pass lambda callback from outside refer [this](https://github.com/ankit-sharechat/ComposeLearningRepo/blob/c48babc7f65dada05a0db866320c8674b252db09/app/src/main/java/com/example/composelearning/DummyState.kt#L58) 